### PR TITLE
fix: fixes typo in release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -53,7 +53,7 @@ autolabeler:
   - label: "deprecated"
     title:
       - "/^deprecate/i"
-  - labeld: "major"
+  - label: "major"
     body:
       - "/BREAKING CHANGE:/"
 template: |


### PR DESCRIPTION
A typo on `release-drafter.yml` was causing release-drafter workflow to raise and error mentioning invalid config.

Logs:

```
| undefined: Config validation errors, please fix the following issues in release-drafter.yml:
| ┌───────────────────────┬────────────────────────────────────┐
| │ Property              │ Error                              │
| ├───────────────────────┼────────────────────────────────────┤
| │ autolabeler.[4].label │ "autolabeler[4].label" is required │
| └───────────────────────┴────────────────────────────────────┘
| { name: 'event', id: '1' }
```

This was due to a typo in the config `labeld` instead of `label`.
