### PR TITLE
feat: Add support for more conventional commit patterns

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -71,7 +71,7 @@ autolabeler:
   # labels to help with changelog grouping
   - label: "release-drafter:dependency"
     title:
-      - '^(?:Bump|(?:chore\(deps\):|chore\(deps-dev\)):)' # Dependency update PR by Dependabot
+      - '/^(?:Bump|(?:chore|build)\((?:deps|deps-dev)\):)\s.*/i' # Dependency update PR by Dependabot
   - label: "release-drafter:chore"
     title:
       - '/^(?:docs|doc|chore|refactor|test)(?:\((?:[^)]+)\))?:\s.*/i'


### PR DESCRIPTION
Dependabot is also using `build(deps)` and `build(deps-dev)` for
dependency updates.
