### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 on:
   push: {}
   pull_request: {}
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/coopnorge/.github/security/code-scanning/2](https://github.com/coopnorge/.github/security/code-scanning/2)

To fix the issue, you should explicitly specify a `permissions` key at either the workflow or job level, limiting the GITHUB_TOKEN to the least privileges necessary. Since this workflow does not interact with repository contents, issues, or pull requests, you can set the permissions to `contents: read` at the workflow or, more specifically, at the job level. The most future-proof fix is to add a minimal `permissions` block at the workflow root, just after the workflow name (if present) or after the triggers (`on`). This change is to be made in the `.github/workflows/build.yaml` file, immediately following the definition of workflow triggers (lines 1-3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
